### PR TITLE
Fixed fatal error with mismatching location schemes

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -130,8 +130,8 @@ export default class Core extends Emitter {
         this.Contextual.name = contextual;
       }
 
-      if (location.origin !== this.location.origin || location.anchor && location.pathname === this.location.pathname) {
-        // We redirect when origins are differents or when there is an anchor.
+      if (location.origin !== this.location.origin || location.scheme !== this.location.scheme || location.anchor && location.pathname === this.location.pathname) {
+        // We redirect when origins are differents, when schemes are different, or when there is an anchor.
         window.location.href = href;
 
       } else {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -47,6 +47,18 @@ export default class Helpers {
   }
 
   /**
+   * Get scheme of an URL
+   *
+   * @arg    {string} url — URL to match
+   * @return {string} Scheme of URL or `null`
+   * @static
+   */
+  getScheme(url) {
+    const match = url.match(/^[^:]+(?=:\/\/)/);
+    return match ? match[0] : null;
+  }
+
+  /**
    * Get anchor in an URL
    *
    * @arg    {string} url — URL to match
@@ -210,7 +222,8 @@ export default class Helpers {
       anchor: this.getAnchor(url),
       origin: this.getOrigin(url),
       params: this.getParams(url),
-      pathname: this.getPathname(url)
+      pathname: this.getPathname(url),
+      scheme: this.getScheme(url)
     };
   }
 }


### PR DESCRIPTION
### Issue
Also mentioned in #113.

Navigating between 2 different domains (such as `http://example.com/` and `https://google.com/`) would be considered a cross-origin transition. In situations like these, Highway will trigger a native page load.

Navigating between 2 different pages on the same domain (such as `https://example.com/page-1/` and `https://example.com/page-2/`) would be considered a same-site transition. Rather than triggering a native page load, Highway will do its magic and provide users with a fancy transition. 

However, problems arise when we look at a different type of transition. Navigating between 2 pages with mismatching schemes while remaining on the same domain (such as `https://example.com/page-1/` and `http://example.com/page-2/`) is actually considered a cross-origin transition as well, due to their changing schemes. Highway does not take this into account while trying to execute a fancy page transition. 

For those interested, more information about these transitions can be found [here](https://web.dev/same-site-same-origin/).
<br>

### Solution 
Taking the URL scheme into account while checking if a fancy transition can be made.